### PR TITLE
Feature Request: 请求增加搜索ID直接跳入漫画详情页功能，请求支持fallback到v1api。

### DIFF
--- a/lib/app/api/comic.dart
+++ b/lib/app/api/comic.dart
@@ -41,12 +41,78 @@ class ComicApi {
     var resultBytes = ApiUtil.decrypt(result);
 
     var data = ComicDetailResponse.fromBuffer(resultBytes);
-    if (data.errno != 0) {
-      throw AppError(data.errmsg, code: data.errno);
-    }
+
+  
+    //patch start
+    if (data.errno == 0) {
     return data.data;
+    }
+    //fallback
+    try{
+    path = "https://api.dmzj.com/dynamic/comicinfo/$comicId.json";
+    var info = await HttpUtil.instance.httpGet(
+      path,
+      queryParameters: ApiUtil.defaultParameter(needLogined: true),
+    );
+    var ret = {
+      "Data": {
+        "Id": info['data']['info']['id'],
+        "Title": info['data']['info']['title'],
+        "Direction": info['data']['info']['direction'],
+        "Islong": info['data']['info']['islong'],
+        "Cover": info['data']['info']['cover'],
+        "Description": info['data']['info']['description'],
+        "LastUpdatetime": info['data']['info']['last_updatetime'],
+        "LastUpdateChapterName": info['data']['info']['last_update_chapter_name'],
+        "FirstLetter": info['data']['info']['first_letter'],
+        "ComicPy": info['data']['info']['first_letter'],
+        "HotNum": 0,//N/A
+        "HitNum": 0,//N/A
+        "LastUpdateChapterId": info['data']['list'][0]['id'],
+        "Types": [
+          {
+            "TagId": 0,//WIP
+            "TagName": info['data']['info']['types'],
+          }
+        ],
+        "Status": [
+          {
+            "TagId": info['data']['info']['status']=="连载中"?2309:2310,
+            "TagName": info['data']['info']['status']
+          }
+        ],
+        "Authors": [
+          {
+            "TagId": 0,//WIP
+            "TagName": info['data']['info']['status']
+          }
+        ],
+        "SubscribeNum": 0,//N/A
+        "Chapters": [
+          {
+            "Title": "连载",//N/A
+            "Data": info['data']['list'].map((e){
+              return {
+                "ChapterId": e['id'],
+                "ChapterTitle": e['chapter_name'],
+                "Updatetime": e['updatetime'],
+                "Filesize": e['filesize'],
+                "ChapterOrder": e['chapter_order']
+              };
+            }),
+          }
+        ],
+        "IsNeedLogin": 1//N/A
+      }
+    };
+    }catch(e){
+      throw AppError(data.errmsg, code: data.errno);//if v1 fails, return v4 error
+    }
+    //patch end
   }
 
+  
+  
   /// 首页-排行榜
   Future<List<ComicRankListItemResponse>> getRankList(
       {int tagId = 0, int byTime = 0, int rankType, int page = 0}) async {

--- a/lib/views/comic/comic_search.dart
+++ b/lib/views/comic/comic_search.dart
@@ -44,6 +44,12 @@ class ComicSearchBarDelegate extends SearchDelegate<String> {
       return Container();
     }
 
+    //patch start
+    if(this.query.contains(RegExp(r'^id\d+$'))){//id12345
+      Utils.openPage(context, int.parse(this.query.replaceAll(RegExp(r'\d'), '')), 1);
+      return Container();//?
+    }
+    //patch end
     return FutureBuilder<List<ComicNSSearchItem>>(
       future: loadData(),
       builder: (BuildContext context,


### PR DESCRIPTION
希望能支持查看v4api神隐的漫画，通过搜索”id#####“跳转至漫画页，并在v4api返回空的情况下回退到v1api。
没学过dart和flutter，下面的patch请视为解释功能的伪代码，我相信这代码肯定无法跑通。
（注：v1api似乎只能查看Chapters的第一组？）